### PR TITLE
Track Page Layout

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -34,6 +34,7 @@
     "vue-router": "^3.1.2",
     "vuelidate": "^0.7.4",
     "vuex": "^3.0.1",
+    "wavesurfer": "^1.3.4",
     "phoenix": "^1.3.0"
   },
   "devDependencies": {

--- a/front/src/App.scss
+++ b/front/src/App.scss
@@ -93,11 +93,7 @@ body {
     color: $shade-100;
     border-bottom: 4px $brand-2 solid;
 }
-#topsearch::placeholder::before {
-    content: "HI";
-    //box-sizing: border-box;
-    //font-family: ForkAwesome;
-}
+
 #topsearch::placeholder {
     color: $brand-1;
 }

--- a/front/src/views/tracks/Show.vue
+++ b/front/src/views/tracks/Show.vue
@@ -1,25 +1,140 @@
 <template>
-  <div>
-    <h4>Show track</h4>
-    <div v-if="isOwner">
-      <a href="#" @click.prevent="editTrack">edit</a> | <a href="#" @click.prevent="deleteTrack">delete</a>
-    </div>
-
-    <div v-if="errors">
+  <div class="row">
+    <div v-if="errors" class="alert alert-danger" role="alert">
       {{ errors }}
     </div>
-    <div v-if="processingDone">
-      Track to show: {{ track }}
+
+    <div class="col-md-8">
+      <div class="d-flex my-4">
+        <img v-bind:src="track.picture_url" class="d-flex mr-3" style="width:112px; height:112px; background: #C8D1F4; ">
+        <div class="flex-fill">
+          <div class="d-flex">
+            <h1 class="flex-fill h3">{{ track.title }}</h1>
+            <div class="d-flex">{{ track.uploaded_on }}</div>
+          </div>
+          <div v-if="processingDone" class="d-flex my-2">
+            <a href="#" role="button" class="btn btn-play btn-primary d-flex mr-2 align-items-center" 
+              v-on:click="Play"
+              ><i class="fa fa-play" aria-hidden="true"></i>
+            </a>
+            <div id="wave" class="flex-fill"></div>
+          </div>
+          <div v-else-if="processingDone" class="alert alert-dark">
+            Track not yet available.
+          </div>
+
+          <div class="pt-1 d-flex">
+            <div class="btn-group" role="group" aria-label="Track actions">
+              <div v-if="isOwner">
+                <button type="button" class="btn btn-link py-0 pl-0" @click.prevent="editTrack"><i class="fa fa-pencil" aria-hidden="true"></i> Edit</button>
+                <button type="button" class="btn btn-link py-0" @click.prevent="deleteTrack"><i class="fa fa-times" aria-hidden="true"></i> Delete</button>
+              </div>
+            </div>
+            <div class="ml-auto align-self-end"><span class="text-secondary">04:20</span> <span class="text-muted">04:33</span></div>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <p>{{ track.description }}</p>
+        <p>Licence: <a v-bind:href="track.metadatas.licence.link">{{ track.metadatas.licence.name }}</a></p>
+      </div>
+
+      <!-- Tabs -->
+      <div>
+        <ul class="nav mt-5 pb-2">
+          <li class="nav-item pr-3">
+            <a class="nav-link" href="#">3 Comments</a>
+          </li>
+          <li class="nav-item px-3 border-left">
+            <a class="nav-link" href="#">10 Likes</a>
+          </li>
+          <li class="nav-item px-3 border-left">
+            <a class="nav-link" href="#">2 Reposts</a>
+          </li>
+          <li class="nav-item px-3 border-left">
+            <a class="nav-link active" href="#">Meta Data</a>
+          </li>
+        </ul>
+        <div class="border-top border-bottom py-4 my-4">
+          <table class="table table-sm my-0">
+            <tbody>
+              <tr>
+                <th scope="row" class="col-md-2 border-0 font-weight-normal">Type</th>
+                <td class="border-0 font-weight-bold">{{ track.metadatas.type }}</td>
+              </tr>
+              <tr>
+                <th scope="row" class="border-0 font-weight-normal">Codec</th>
+                <td class="border-0 font-weight-bold">{{ track.metadatas.codec }}</td>
+              </tr>
+              <tr>
+                <th scope="row" class="border-0 font-weight-normal">Channels</th>
+                <td class="border-0 font-weight-bold">{{ track.metadatas.channels }}</td>
+              </tr>
+              <tr>
+                <th scope="row" class="border-0 font-weight-normal">Sample rate</th>
+                <td class="border-0 font-weight-bold">{{ track.metadatas.rate }}</td>
+              </tr>
+              <tr>
+                <th scope="row" class="border-0 font-weight-normal">Bit rate</th>
+                <td class="border-0 font-weight-bold">{{ track.metadatas.bitrate }} {{ track.metadatas.bitrate_mode }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
     </div>
-    <div v-else-if="processingDone">
-      Track not yet available.
+
+    <div class="col-md-4 d-flex flex-column">
+
+      <!-- Profile Card -->
+      <div class="card my-4">
+        <div class="card-body py-3 px-3">
+          <div class="d-flex mb-2">
+            <div class="d-flex rounded-circle mr-2" style="width:96px; height:96px; overflow:hidden">
+              <img src="https://lastfm-img2.akamaized.net/i/u/770x0/a4c9b3bb4d0443abc3bac418835c66a7.jpg#a4c9b3bb4d0443abc3bac418835c66a7" alt="Downliners Sekt" style="height:96px;">
+            </div>
+            <div class="align-self-center">
+              <h2 class="h2 m-0">{{ track.user }}</h2>
+              <p class="h3 font-weight-normal m-0">@alexsleepy <button type="button" class="btn btn-primary btn-sm">Follow</button></p>
+              <p class="text-muted m-0">Follows you</p>
+            </div>
+          </div>
+          <p class="card-text">
+            For most of us, the idea of astronomy is something we directly connect to “stargazing”, telescopes and seeing magnificent displays in the heavens. And to be sure, that is the exciting area of astronomy that accounts for it’s hu... <a href="#">read more</a>
+          </p>
+          <ul class="nav nav-fill">
+              <li class="nav-item border-right">
+                <a class="nav-link px-2" href="#"><p class="h3 font-weight-normal m-0">59</p><p class="m-0">Tracks</p></a>
+              </li>
+              <li class="nav-item border-right">
+                <a class="nav-link px-2" href="#"><p class="h3 font-weight-normal m-0">5</p><p class="m-0">Albums</p></a>
+              </li>
+              <li class="nav-item border-right">
+                <a class="nav-link px-2" href="#"><p class="h3 font-weight-normal m-0">841</p><p class="m-0">Followers</p></a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link px-2" href="#"><p class="h3 font-weight-normal m-0">12</p><p class="m-0">Following</p></a>
+              </li>
+          </ul>
+        </div>
+      </div>
+
+
+      <!-- Footer -->
+      <footer class="mt-auto mb-4">Powered by <a href="https://github.com/rhaamo/reel2bits">Reel2Bits</a></footer>
+
     </div>
+
+
   </div>
 </template>
 
 <script>
 import { mapState } from 'vuex'
 import apiService from '../../services/api/api.service.js'
+import WaveSurfer from 'wavesurfer'
 
 export default {
   data: () => ({
@@ -45,6 +160,16 @@ export default {
   created () {
     this.fetchTrack()
   },
+  mounted () {
+    this.wavesurfer = WaveSurfer.create({
+      container: '#wave',
+      height: 40,
+      progressColor: '#C728B6',
+      waveColor: '#C8D1F4',
+      cursorColor: '#313DF2'
+    })
+    this.wavesurfer.load(this.track.media_transcoded)
+  },
   methods: {
     async fetchTrack () {
       try {
@@ -66,6 +191,10 @@ export default {
           .then(this.$router.push({ name: 'user-profile', params: { name: this.$store.state.users.currentUser.screen_name } })
           )
       }
+    },
+    Play: function () {
+      this.wavesurfer.playPause()
+      console.log(this.track.media_transcoded)
     }
   }
 }

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -10254,6 +10254,11 @@ watchpack@^1.6.0:
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
 
+wavesurfer@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/wavesurfer/-/wavesurfer-1.3.4.tgz#17908abd20da11a8db460c5a176679621d519bfa"
+  integrity sha1-F5CKvSDaEajbRgxaF2Z5Yh1Rm/o=
+
 wbuf@^1.1.0, wbuf@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df"


### PR DESCRIPTION
- there is mock data in some places (mostly about user profile)
- for some reason wavesurfer works only if there are no references to {{ track }} in template 
- it'd be nice to have user profile card and footer to be in separate components